### PR TITLE
To run GitHub Actions only on pull request

### DIFF
--- a/.github/workflows/on-push-lint-and-build.yml
+++ b/.github/workflows/on-push-lint-and-build.yml
@@ -1,5 +1,7 @@
-name: on-push-lint-and-build
-on: [push]
+name: on-pull-request-lint-and-build
+on:
+  pull_request:
+    branches: [main]
 jobs:
   checks-app-code-standard:
     runs-on: ubuntu-latest
@@ -7,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.19.3'
+          node-version: "14.19.3"
       - run: npm install
       - run: npm run prettier:check
       - run: npm run lint


### PR DESCRIPTION
Running GitHub Actions on the main branch only wastes CI minutes because we're not enforcing developers to do pull requests prior to merging code in the main branch. https://stacktrek.slack.com/archives/C050ZV89FAS/p1682517068893969