### PR TITLE
Fix prettier command not working on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint --max-warnings=0 --ext js,ts,tsx src",
-    "prettier": "prettier --write 'src/**/*'",
-    "prettier:check": "prettier --check 'src/**/*'"
+    "prettier": "prettier --write src/**/*",
+    "prettier:check": "prettier --check src/**/*"
   },
   "dependencies": {
     "flowbite": "^1.6.5",


### PR DESCRIPTION
### Propose Change

With this change, we are able to run `npm run prettier:check`, and `npm run prettier` without issue on WIndows Terminal

![image](https://user-images.githubusercontent.com/16744414/234756135-1b056a4a-c74e-4dec-a909-725968aa608d.png)

Still works fine for Bash Terminal

![image](https://user-images.githubusercontent.com/16744414/234756222-64c2ea11-c343-4316-b294-cc13e21dd685.png)
