### PR TITLE
Set prettier as the default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,21 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
### Current Issue

Saving files doesn't do autoformat.

![not autoformatting](https://github.com/Stacktrek-Training/stack-ilearning/assets/16744414/db24bebb-0402-47b7-a053-5e74c12dd6b5)

I made a PR before https://github.com/Stacktrek-Training/stack-ilearning/pull/2 it was working on my end because I had a user setting that has configured to use prettier as a default formatter.

### Propose Change

Assuming we have already installed prettier via `npm install` and also [VSCode Pretter extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

Saving files will autoformat

![autoformat](https://github.com/Stacktrek-Training/stack-ilearning/assets/16744414/26ce0bb9-9cc8-469d-8ca9-15bb72f483da)





